### PR TITLE
 Cleanup method in Compiler

### DIFF
--- a/src/main/java/jce/compiling/Compiler.java
+++ b/src/main/java/jce/compiling/Compiler.java
@@ -118,7 +118,7 @@ public class Compiler {
      * @param paths paths of files that need to be deleted after compiling
      */
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    private void cleanup(String[] paths){
+    public static void cleanup(String[] paths){
         if (paths == null) return;
 
         for (String path : paths) {


### PR DESCRIPTION
change [cleanup method](https://github.com/MohammadNik/JavaCompileEngine/blob/master/src/main/java/jce/compiling/Compiler.java) access-modifier from *private* to *public* and make it *static*